### PR TITLE
Added runtime auto-syncing ability for 'app.js' file changes with the 'appDev.js' file.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4617,6 +4617,11 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
+    "dayjs": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.3.tgz",
+      "integrity": "sha512-/2fdLN987N8Ki7Id8BUN2nhuiRyxTLumQnSQf9CNncFCyqFsSKb9TNhzRYcC8K8eJSJOKvbvkImo/MKKhNi4iw=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -13120,6 +13125,12 @@
       "requires": {
         "lodash": "^4.17.15"
       }
+    },
+    "webpack-shell-plugin": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-shell-plugin/-/webpack-shell-plugin-0.5.0.tgz",
+      "integrity": "sha1-Kbih2A3erg3bEOcpZn9yhlPCx0I=",
+      "dev": true
     },
     "webpack-sources": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "lint:js": "npm run lint:eslint -- . ",
     "lint:eslint": "eslint --ignore-path .gitignore",
     "prettify": "prettier --write",
-    "start": "node server/scripts/devServerPreBuild.js && node server/server.js"
+    "start": "npm run reinit:dev:root && npm run server",
+    "reinit:dev:root": "rm -rf src/appDev.js && npm run create:dev:root",
+    "create:dev:root": "node server/scripts/devServerPreBuild.js",
+    "server": "node server/server.js"
   },
   "repository": {
     "type": "git",
@@ -28,6 +31,7 @@
   "homepage": "https://github.com/mahidulalvi/mithril-boilerplate#readme",
   "dependencies": {
     "@formatjs/intl": "^1.4.13",
+    "dayjs": "^1.10.3",
     "express": "^4.17.1",
     "lodash": "4.17.20",
     "mithril": "^2.0.4",
@@ -57,6 +61,7 @@
     "webpack-cli": "^4.3.1",
     "webpack-dev-middleware": "^3.7.2",
     "webpack-hot-middleware": "2.25.0",
+    "webpack-shell-plugin": "^0.5.0",
     "workbox-webpack-plugin": "^5.1.3"
   }
 }

--- a/server/scripts/devServerPreBuild.js
+++ b/server/scripts/devServerPreBuild.js
@@ -1,23 +1,77 @@
+/**
+ * script file responsible for creating development server root file (appDev.js)
+ * and enabling HMR - Hot Module Replacement in development server.
+ *
+ * the appDev.js file is also ignored in git. The file is created/overwritten
+ * every time the 'npm run start' command is executed - which runs this file
+ * before starting the development server.
+ *
+ * if the app.js file itself is updated, then 'webpack-shell-plugin' runs this
+ * script file again to sync the changes.
+ *
+ * see in scripts section of package.json for the commands.
+ */
+
 const glob = require('glob');
 const fs = require('fs');
+const dayjs = require('dayjs');
 
-const hotReloadableFiles = glob
-  .sync('**/*.*', { cwd: `${process.cwd()}/src` })
-  .filter(filePath => filePath !== 'app.js')
-  .map(filePath => (filePath = `'./${filePath}'`));
+const appJsFileStats = fs.statSync('./src/app.js');
+const appJsFileModificationDateInUnixMs = dayjs(appJsFileStats.mtime).valueOf();
 
-// handling hot reload of hotReloadableFiles
-const codeToAppend = `\nif (module.hot) {
-  module.hot.accept(
-    [${hotReloadableFiles.toString()}],
-    // callback to execute when components are updated - rerendering mithril
-    () => mountApp()
-  );
-}`;
+const appDevJsFileExists = fs.existsSync('./src/appDev.js');
+let appDevJsFileStats;
+let appDevJsFileModificationDateInUnixMs;
 
-const appJsFileContent = fs.readFileSync('src/app.js');
-const appDevJsFileContent = appJsFileContent + codeToAppend;
+if (appDevJsFileExists) {
+  appDevJsFileStats = fs.statSync('./src/appDev.js');
+  appDevJsFileModificationDateInUnixMs = dayjs(
+    appDevJsFileStats.mtime
+  ).valueOf();
+}
 
-fs.writeFileSync('src/appDev.js', appDevJsFileContent);
+const currentDateInUnixMs = dayjs().valueOf();
 
-console.log('==> server/scripts/devServerPreBuild.js ran successfully.');
+/**
+ * if appDev.js file doesn't exist, this is the first time running the development
+ * server, so the file is cloned from app.js file and HMR related code is
+ * appended to it.
+ *
+ * the same is done if the modification date of appDev.js file is smaller than
+ * app.js file - which means the app.js file was updated after the appDev.js
+ * was updated, so the changes need to be synced.
+ *
+ * the process is also followed if currentDateInUnixMs is smaller than the
+ * modification date of appDev.js file. This is added because there might be
+ * a case when the date needs to be changed to the past for some development
+ * purpose. This is only necessary if the server is not restarted - as the
+ * appDev.js file will be recreated upon restart.
+ */
+if (
+  !appDevJsFileExists ||
+  appDevJsFileModificationDateInUnixMs < appJsFileModificationDateInUnixMs ||
+  currentDateInUnixMs < appDevJsFileModificationDateInUnixMs
+) {
+  const hotReloadableFiles = glob
+    .sync('**/*.*', { cwd: `${process.cwd()}/src` })
+    .map(filePath => (filePath = `'./${filePath}'`));
+
+  if (hotReloadableFiles.indexOf('./appDev.js') === -1)
+    hotReloadableFiles.push("'./appDev.js'");
+
+  // handling hot reload of hotReloadableFiles
+  const codeToAppend = `\nif (module.hot) {
+    module.hot.accept(
+      [${hotReloadableFiles.toString()}],
+      // callback to execute when components are updated - rerendering mithril
+      () => mountApp()
+    );
+  }`;
+
+  const appJsFileContent = fs.readFileSync('src/app.js');
+  const appDevJsFileContent = appJsFileContent + codeToAppend;
+
+  fs.writeFileSync('src/appDev.js', appDevJsFileContent);
+
+  console.log('==> server/scripts/devServerPreBuild.js ran successfully.');
+}

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -28,6 +28,8 @@ const workboxPlugin = require('workbox-webpack-plugin');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+const WebpackShellPlugin = require('webpack-shell-plugin');
+
 module.exports = {
   mode: 'development',
   entry: ['./src/appDev.js', 'webpack-hot-middleware/client?reload=true'],
@@ -46,6 +48,9 @@ module.exports = {
       swDest: 'sw.js',
       clientsClaim: true,
       skipWaiting: false,
+    }),
+    new WebpackShellPlugin({
+      onBuildExit: ['node server/scripts/devServerPreBuild.js'],
     }),
   ],
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,13 +1,12 @@
 /**
- * source for entry file for webpack development env. build
+ * root file for the application
  *
- * development build webpack entry file is src/appDev.js which is a HMR enabled
- * version of this file. The appDev.js file is also ignored in git. This file
- * is created/overwritten every time npm run start command is executed.
+ * development build webpack entry file is src/appDev.js which is a HMR enabled,
+ * temporary & only for development server - version of the app.js file.
  *
- * see in scripts section of package.json for more details.
+ * read comments in 'server/scripts/devServerPreBuild.js' file for more details.
  *
- * we will use this app.js file in production env. where
+ * we will use this app.js file in production env. build where
  * HMR - Hot Module Replacement is not needed.
  */
 


### PR DESCRIPTION
In the previous, the development server entry file, 'appDev.js', would be automatically created on server start from 'app.js' file, but couldn't be updated on runtime if 'app.js' file is updated. Now the changes are automatically synced.