### PR TITLE
Enhanced the Redux Mithril binding 'connect' function through Route Resolvers.

### DIFF
--- a/src/RouteResolver.js
+++ b/src/RouteResolver.js
@@ -1,0 +1,34 @@
+/**
+ * returns a RouteResolver object.
+ * https://mithril.js.org/route.html#routeresolver
+ *
+ * has ability to handle Redux store connected components as well as
+ * non-connected components.
+ *
+ * the render method gets the latest props from Redux store
+ * & supplies it to the component's vnode attrs on rerender
+ * if the component is connected to Redux.
+ */
+
+const RouteResolver = routeParameter => {
+  const isConnectedComponent = routeParameter && routeParameter.initialVnode;
+
+  let routeComponent = routeParameter;
+  let getRouteComponentAttrs = () => {};
+
+  if (isConnectedComponent) {
+    routeComponent = routeParameter.initialVnode;
+    getRouteComponentAttrs = routeParameter.getVnodeAttrs;
+  }
+
+  return {
+    onmatch: () => routeComponent,
+    render: vnode => {
+      vnode.attrs = getRouteComponentAttrs();
+
+      return vnode;
+    },
+  };
+};
+
+export default RouteResolver;

--- a/src/app.js
+++ b/src/app.js
@@ -11,15 +11,16 @@
  */
 
 import m from 'mithril';
+import RouteResolver from './RouteResolver.js';
 import ExampleMithrilComponent from './components/ExampleMithrilComponent/ExampleMithrilComponent.js';
 import ExampleMithrilComponent2 from './components/ExampleMithrilComponent/ExampleMithrilComponent2.js';
 import ExampleMithrilComponent3 from './components/ExampleMithrilComponent/ExampleMithrilComponent3.js';
 
 const mountApp = () =>
   m.route(document.body, '/example1', {
-    '/example1': ExampleMithrilComponent,
-    '/example2': ExampleMithrilComponent2,
-    '/example3': ExampleMithrilComponent3,
+    '/example1': RouteResolver(ExampleMithrilComponent),
+    '/example2': RouteResolver(ExampleMithrilComponent2),
+    '/example3': RouteResolver(ExampleMithrilComponent3),
   });
 
 mountApp();

--- a/src/components/ExampleMithrilComponent/ExampleMithrilComponent2.js
+++ b/src/components/ExampleMithrilComponent/ExampleMithrilComponent2.js
@@ -63,8 +63,27 @@ const mapStateToVnodeAttrs = createStructuredSelector({
   locale: makeSelectLocale(),
 });
 
+/**
+ * usually our store subscription callback (in src/reduxConfig/config.js) picks
+ * up dispatched actions before Mithril can auto redraw via firing
+ * event handler functions (e.g. button clicks. increaseCount
+ * is an event handler function). the subscription callback then manually
+ * calls the redraw function.
+ *
+ * for this reason & also because the redraw calls are throttled,
+ * multiple DOM updates do not occur even after 'Redux store
+ * subscription callback' initiated manual redraw calls and firing of
+ * event handlers initiated auto redraw calls in quick succession.
+ *
+ * dispatch function 'increaseCount' for counter onclick
+ * event handler can be updated to turn off Mithril's default redraw behaviour
+ * explicityly by setting event.redraw = false.
+ */
 const mapDispatchToVnodeAttrs = dispatch => ({
-  increaseCount: () => dispatch(doubleCounter()),
+  increaseCount: () => {
+    // event.redraw = false;
+    dispatch(doubleCounter());
+  },
   changeSelectTagOption: value => dispatch(changeLocale(value)),
 });
 

--- a/src/reduxConfig/config.js
+++ b/src/reduxConfig/config.js
@@ -1,6 +1,7 @@
 import { createStore, combineReducers } from 'redux';
 import { exampleMithrilComponentReducer } from '../components/ExampleMithrilComponent/reducer.js';
 import { i18nReducer } from '../i18nConfig/reducer.js';
+import m from 'mithril';
 
 const rootReducer = combineReducers({
   exampleComponent: exampleMithrilComponentReducer,
@@ -11,5 +12,16 @@ const store = createStore(
   rootReducer,
   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 );
+
+/**
+ * updating the DOM when an action is dispatched to the Redux store.
+ * this will cause components to rerender with latest props from store.
+ * see the src/RouteResolver.js and src/reduxConfig/connect.js files for
+ * more details on how the component gets the latest props.
+ *
+ * a more efficient method for redrawing on store update might be
+ * implemented later.
+ */
+store.subscribe(() => m.redraw());
 
 export { store };

--- a/src/reduxConfig/connect.js
+++ b/src/reduxConfig/connect.js
@@ -1,9 +1,11 @@
 /**
- * connect is a function that returns a route resolver for the
- *  child component.
+ * connect is a function which returns an object containing the
+ * component & a function to get the component's latest vnode attrs.
  *
- * A route resolver is necessary for supplying the child component with the
- * updated props from redux store on component render when store is updated.
+ * this function, when called upon rerendering, supplies the component with
+ * the latest vnode attrs from Redux store.
+ *
+ * see src/RouteResolver.js for implementation.
  */
 
 import { store } from './config.js';
@@ -12,28 +14,23 @@ export const connect = (
   initialVnode,
   mapStateToVnodeAttrs,
   mapDispatchToVnodeAttrs
-) => {
-  let currentAttrValues = {};
-  let attrsWithDispatch = {};
+) => ({
+  initialVnode,
+  getVnodeAttrs: () => {
+    let attrs = {};
+    let attrsWithDispatch = {};
 
-  if (mapStateToVnodeAttrs) {
-    currentAttrValues = mapStateToVnodeAttrs(store.getState());
+    if (mapStateToVnodeAttrs) {
+      attrs = mapStateToVnodeAttrs(store.getState());
+    }
 
-    store.subscribe(() => {
-      currentAttrValues = mapStateToVnodeAttrs(store.getState());
-    });
-  }
+    if (mapDispatchToVnodeAttrs) {
+      attrsWithDispatch = mapDispatchToVnodeAttrs(store.dispatch);
+    }
 
-  if (mapDispatchToVnodeAttrs) {
-    attrsWithDispatch = mapDispatchToVnodeAttrs(store.dispatch);
-  }
-
-  // returns a route resolver with updated attr values on render
-  return {
-    onmatch: () => initialVnode,
-    render: vnode => {
-      vnode.attrs = { ...currentAttrValues, ...attrsWithDispatch };
-      return vnode;
-    },
-  };
-};
+    return {
+      ...attrs,
+      ...attrsWithDispatch,
+    };
+  },
+});


### PR DESCRIPTION
In the previous, the store was subscribed inside the 'connect' function. It was not ideal to implement other possible Route Resolver functionalities (e.g. an application layout component) as the 'connect' function was returning a Route Resolver to deliver updated vnode attrs to the component on store update. So a new function 'RouteResolver' was created to return a Route Resolver object. This function can handle connected & non connected components as params and returns the components along with its vnode attrs through a Route Resolver object.

The connect function now solely handles getting latest props from the store & is not concerned with store subscriptions. The store is subscribed in the Redux config file (src/reduxConfig/config.js) and m.redraw() is called in the subscription callback. A more efficient way of redrawing rather than calling it on every dispatch call may be implemented later.